### PR TITLE
correct an undefined behavior (fails in GCC 4.8.1 with -O2)

### DIFF
--- a/parser/parsePartitions.c
+++ b/parser/parsePartitions.c
@@ -60,7 +60,7 @@ extern char secondaryStructureFileName[1024];
 
 extern char seq_file[1024];
 
-extern char *protModels[12];
+extern char *protModels[NUM_PROT_MODELS];
 
 static boolean lineContainsOnlyWhiteChars(char *line)
 {


### PR DESCRIPTION
The type of protModels is not consistent between files, causing undefined
behavior leading to crashes under certain circumstances. For detail see thread
here:
http://www.reddit.com/r/programming/comments/257dn6/the_compiler_is_always_right_nathans_blog/cheq5pw