### PR TITLE
quartets: do not close unopened file in non-master MPI processes

### DIFF
--- a/examl/quartets.c
+++ b/examl/quartets.c
@@ -611,5 +611,6 @@ void computeQuartets(tree *tr, analdef *adef)
       assert(0);
     }
   
-  fclose(f);
+  if(processID == 0)
+    fclose(f);
 }


### PR DESCRIPTION
(fixes a segfault at the end of quartet computation)