### PR TITLE
Enable propagation of external {C,LD,CPP}FLAGS

### DIFF
--- a/examl/Makefile.AVX.gcc
+++ b/examl/Makefile.AVX.gcc
@@ -8,7 +8,7 @@ COMMON_FLAGS = -D__SIM_SSE3 -D__AVX -D_OPTIMIZED_FUNCTIONS -msse3 -D_GNU_SOURCE 
 OPT_FLAG_1 = -O1
 OPT_FLAG_2 = -O2
 
-CFLAGS = $(COMMON_FLAGS) $(OPT_FLAG_2)
+CFLAGS += $(COMMON_FLAGS) $(OPT_FLAG_2)
 
 LIBRARIES = -lm -mavx
 
@@ -21,13 +21,13 @@ all : clean examl-AVX
 GLOBAL_DEPS = axml.h globalVariables.h ../versionHeader/version.h
 
 examl-AVX : $(objs)
-	$(CC) -o examl-AVX $(objs) $(LIBRARIES) 
+	$(CC) -o examl-AVX $(objs) $(LIBRARIES) $(LDFLAGS)
 
 avxLikelihood.o : avxLikelihood.c $(GLOBAL_DEPS)
-	$(CC) $(CFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c
 
 models.o : models.c $(GLOBAL_DEPS)
-	 $(CC) $(COMMON_FLAGS) $(OPT_FLAG_1) -c -o models.o models.c
+	$(CC) $(CFLAGS) $(COMMON_FLAGS) $(OPT_FLAG_1) $(CPPFLAGS) -c -o models.o models.c
 
 bipartitionList.o : bipartitionList.c $(GLOBAL_DEPS)
 evaluatePartialSpecialGeneric.o : evaluatePartialSpecialGeneric.c $(GLOBAL_DEPS)

--- a/examl/Makefile.OMP.AVX.gcc
+++ b/examl/Makefile.OMP.AVX.gcc
@@ -8,7 +8,7 @@ COMMON_FLAGS = -D__SIM_SSE3 -D__AVX -D_USE_OMP -fopenmp -D_OPTIMIZED_FUNCTIONS -
 OPT_FLAG_1 = -O1
 OPT_FLAG_2 = -O2
 
-CFLAGS = $(COMMON_FLAGS) $(OPT_FLAG_2)
+CFLAGS += $(COMMON_FLAGS) $(OPT_FLAG_2)
 
 LIBRARIES = -lm -mavx -fopenmp
 
@@ -21,7 +21,7 @@ all : clean examl-OMP-AVX
 GLOBAL_DEPS = axml.h globalVariables.h ../versionHeader/version.h
 
 examl-OMP-AVX : $(objs)
-	$(CC) -o examl-OMP-AVX $(objs) $(LIBRARIES) 
+	$(CC) -o examl-OMP-AVX $(objs) $(LIBRARIES) $(LDFLAGS)
 
 avxLikelihood.o : avxLikelihood.c $(GLOBAL_DEPS)
 	$(CC) $(CFLAGS) -mavx -c -o avxLikelihood.o avxLikelihood.c

--- a/examl/Makefile.OMP.SSE3.gcc
+++ b/examl/Makefile.OMP.SSE3.gcc
@@ -8,7 +8,7 @@ COMMON_FLAGS = -D_USE_OMP -fopenmp -D_GNU_SOURCE -D__SIM_SSE3  -msse3 -fomit-fra
 OPT_FLAG_1 = -O1 
 OPT_FLAG_2 = -O2
 
-CFLAGS = $(COMMON_FLAGS) $(OPT_FLAG_2)
+CFLAGS += $(COMMON_FLAGS) $(OPT_FLAG_2)
 
 LIBRARIES = -lm -fopenmp
 
@@ -21,7 +21,7 @@ all : clean examl-OMP
 GLOBAL_DEPS = axml.h globalVariables.h ../versionHeader/version.h
 
 examl-OMP : $(objs)
-	$(CC) -o examl-OMP $(objs) $(LIBRARIES) 
+	$(CC) -o examl-OMP $(objs) $(LIBRARIES) $(LDFLAGS)
 
 models.o : models.c $(GLOBAL_DEPS)
 	 $(CC) $(COMMON_FLAGS) $(OPT_FLAG_1) -c -o models.o models.c

--- a/examl/Makefile.SSE3.gcc
+++ b/examl/Makefile.SSE3.gcc
@@ -9,7 +9,7 @@ COMMON_FLAGS = -D_GNU_SOURCE -D__SIM_SSE3  -msse3 -fomit-frame-pointer -funroll-
 OPT_FLAG_1 = -O1 
 OPT_FLAG_2 = -O2
 
-CFLAGS = $(COMMON_FLAGS) $(OPT_FLAG_2)
+CFLAGS += $(COMMON_FLAGS) $(OPT_FLAG_2)
 
 LIBRARIES = -lm
 
@@ -22,7 +22,7 @@ all : clean examl
 GLOBAL_DEPS = axml.h globalVariables.h ../versionHeader/version.h
 
 examl : $(objs)
-	$(CC) -o examl $(objs) $(LIBRARIES) 
+	$(CC) -o examl $(objs) $(LIBRARIES) $(LDFLAGS)
 
 models.o : models.c $(GLOBAL_DEPS)
 	 $(CC) $(COMMON_FLAGS) $(OPT_FLAG_1) -c -o models.o models.c


### PR DESCRIPTION
Hello! 

This patch is from the Debian package of ExaML as we add additional flags to the build for https://wiki.debian.org/Hardening

It will be useful to other systems that want to package ExaML as well. Thank you for your contribution to Open Science / Open Source!